### PR TITLE
Fork merge

### DIFF
--- a/.github/workflows/tutor_build_image.yml
+++ b/.github/workflows/tutor_build_image.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Build the image
         # see: https://docs.tutor.overhang.io/configuration.html
         run: tutor images build openedx \
-		--build-arg EDX_PLATFORM_REPOSITORY=https://github.com/Turn-The-Bus/edx-platform.git \
-		--build-arg EDX_PLATFORM_VERSION=release-2022-03-16-04.47
+		  --build-arg EDX_PLATFORM_REPOSITORY=https://github.com/Turn-The-Bus/edx-platform.git \
+		  --build-arg EDX_PLATFORM_VERSION=release-2022-03-16-04.47
 
       - name: Push the image
         run: |

--- a/.github/workflows/tutor_build_image.yml
+++ b/.github/workflows/tutor_build_image.yml
@@ -100,8 +100,9 @@ jobs:
       - name: Build the image
         # see: https://docs.tutor.overhang.io/configuration.html
         run: tutor images build openedx \
-		  --build-arg EDX_PLATFORM_REPOSITORY=https://github.com/Turn-The-Bus/edx-platform.git \
-		  --build-arg EDX_PLATFORM_VERSION=release-2022-03-16-04.47
+          --build-arg EDX_PLATFORM_REPOSITORY=https://github.com/Turn-The-Bus/edx-platform.git \
+          --build-arg EDX_PLATFORM_VERSION=release-2022-03-16-04.47
+
 
       - name: Push the image
         run: |


### PR DESCRIPTION
added tutor build image via fork 
#100 line in tutor_build_image.yml file 
- name: Build the image
        # see: https://docs.tutor.overhang.io/configuration.html
        run: tutor images build openedx \
		--build-arg EDX_PLATFORM_REPOSITORY=https://github.com/Turn-The-Bus/edx-platform.git \
		--build-arg EDX_PLATFORM_VERSION=release-2022-03-16-04.47
